### PR TITLE
Add Audit Report + Console Log Progress

### DIFF
--- a/lib/NexposeRunner/version.rb
+++ b/lib/NexposeRunner/version.rb
@@ -1,4 +1,4 @@
 module NexposeRunner
-    VERSION = '0.0.6'
+    VERSION = '0.0.7'
 end
 

--- a/lib/nexpose-runner/constants.rb
+++ b/lib/nexpose-runner/constants.rb
@@ -10,6 +10,7 @@ module CONSTANTS
   VULNERABILITY_REPORT_NAME = 'nexpose-vulnerability-report.csv'
   SOFTWARE_REPORT_NAME = 'nexpose-software-report.csv'
   POLICY_REPORT_NAME = 'nexpose-policy-report.csv'
+  AUDIT_REPORT_NAME = 'nexpose-audit-report.html'
 
   VULNERABILITY_REPORT_QUERY = 'SELECT DISTINCT
                                   ip_address,

--- a/lib/nexpose-runner/scan.rb
+++ b/lib/nexpose-runner/scan.rb
@@ -56,8 +56,7 @@ module NexposeRunner
         sleep(3)
         stats = nsc.scan_statistics(scan.id)
  	status = stats.status
-	progress = stats.tasks.completed / stats.tasks.pending * 100
-        puts "Current #{run_details.site_name} scan status: #{status.to_s} : #{progress.to_s}% completed"
+        puts "Current #{run_details.site_name} scan status: #{status.to_s} -- PENDING: #{stats.tasks.pending.to_s} ACTIVE: #{stats.tasks.active.to_s} COMPLETED #{stats.tasks.completed.to_s}"
       end while status == Nexpose::Scan::Status::RUNNING
     end
 

--- a/lib/nexpose-runner/scan.rb
+++ b/lib/nexpose-runner/scan.rb
@@ -55,9 +55,10 @@ module NexposeRunner
       begin
         sleep(3)
         stats = nsc.scan_statistics(scan.id)
+ 	status = stats.status
 	progress = stats.tasks.completed / stats.tasks.pending * 100
         puts "Current #{run_details.site_name} scan status: #{status.to_s} : #{progress.to_s}% completed"
-      end while stats.status == Nexpose::Scan::Status::RUNNING
+      end while status == Nexpose::Scan::Status::RUNNING
     end
 
     def self.create_site(run_details, nsc)


### PR DESCRIPTION
- Creates an audit-report on each scan
- Gives information about what the scan is doing instead of the never ending "Running..."  text. 
