### PR TITLE
Revert "Fixes #10 - Bumping Nexpose-client version"

### DIFF
--- a/NexposeRunner.gemspec
+++ b/NexposeRunner.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'nexpose', '7.1.1'
+  spec.add_dependency 'nexpose', '0.8.3'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake', '< 11.0'


### PR DESCRIPTION
This reverts commit 086c046d891adfbc5093dde5d17f18d688c2ad3c.